### PR TITLE
Fix: 자가진단 내역 보기 및 결과페이지 수정

### DIFF
--- a/src/pages/AITestResult.jsx
+++ b/src/pages/AITestResult.jsx
@@ -304,10 +304,27 @@ const AITestResult = () => {
               <StandardAndQuestion key={item.standardName}>
                 <StandardContainer>
                   <Standard>{item.standardName}</Standard>
+                  {item.description
+                    .split(".")
+                    .filter(Boolean)
+                    .map((sentence, index) => (
+                      <Description key={index}>{sentence.trim()}.</Description>
+                    ))}
                 </StandardContainer>
                 <QuestionContainer>
                   {item.qnaPairDtoList?.map((qna, index) => (
-                    <Question key={index}>{qna.question}</Question>
+                    <Question key={index}>
+                      {qna.question}
+                      <Answer>
+                        {" "}
+                        ▶{" "}
+                        {qna.answer === "NOT_APPLICABLE"
+                          ? "해당 없음"
+                          : qna.answer === "NO"
+                          ? "아니오"
+                          : qna.answer}
+                      </Answer>
+                    </Question>
                   ))}
                 </QuestionContainer>
               </StandardAndQuestion>
@@ -416,7 +433,7 @@ const StandardAndQuestion = styled.div`
 const StandardContainer = styled.div`
   display: flex;
   flex-direction: column;
-  padding: 1rem 2rem;
+  padding: 1rem 2rem 0.5rem 2rem;
   box-sizing: border-box;
   background-color: ${color.primary};
   border-radius: 1.8rem;
@@ -424,6 +441,13 @@ const StandardContainer = styled.div`
 
 const Standard = styled.h3`
   color: white;
+`;
+
+const Description = styled.div`
+  margin-bottom: 1rem;
+  padding: 1rem;
+  background-color: white;
+  border-radius: 1rem;
 `;
 
 const QuestionContainer = styled.div`
@@ -436,4 +460,9 @@ const Question = styled.p`
   padding-bottom: 1rem;
   border-bottom: solid 0.05rem #ddd;
   line-height: 1.7;
+`;
+
+const Answer = styled.p`
+  margin-bottom: 0;
+  color: red;
 `;

--- a/src/pages/TestHistory.jsx
+++ b/src/pages/TestHistory.jsx
@@ -63,58 +63,66 @@ const TestHistory = () => {
           </TabContainer>
 
           <TableContainer>
-            <Table>
-              <thead>
-                <tr>
-                  <Th>번호</Th>
-                  {activeTab === "developer" && <Th>모델 이름</Th>}
-                  <Th>검사 결과</Th>
-                  <Th>검사 일시</Th>
-                  <Th>결과보기</Th>
-                </tr>
-              </thead>
-              <tbody>
-                {(activeTab === "developer" ? AITests : UserTests).map(
-                  (item, index) => (
-                    <tr key={item.diagnosisId}>
-                      <Td style={{ width: "10%" }}>{index + 1}</Td>
-                      {activeTab === "developer" && (
-                        <Td style={{ width: "30%" }}>{item.llmName}</Td>
-                      )}
-                      <Td
-                        style={{
-                          width: activeTab === "developer" ? "20%" : "30%",
-                        }}
-                      >
-                        {item.totalScoreToString}
-                      </Td>
-                      <Td
-                        style={{
-                          width: activeTab === "developer" ? "30%" : "55%",
-                        }}
-                      >
-                        {new Date(item.createdAt).toLocaleString()}
-                      </Td>
-                      <Td
-                        style={{
-                          width: activeTab === "developer" ? "10%" : "5%",
-                        }}
-                      >
-                        <ResultButton
-                          href={`/${
-                            activeTab === "developer"
-                              ? "aiTestResult"
-                              : "userTestResult"
-                          }/${item.diagnosisId}`}
+            {(activeTab === "developer" ? AITests : UserTests).length === 0 ? (
+              <p
+                style={{ textAlign: "center", padding: "2rem", color: "#666" }}
+              >
+                검사 내역이 없습니다.
+              </p>
+            ) : (
+              <Table>
+                <thead>
+                  <tr>
+                    <Th>번호</Th>
+                    {activeTab === "developer" && <Th>모델 이름</Th>}
+                    <Th>검사 결과</Th>
+                    <Th>검사 일시</Th>
+                    <Th>결과보기</Th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {(activeTab === "developer" ? AITests : UserTests).map(
+                    (item, index) => (
+                      <tr key={item.diagnosisId}>
+                        <Td style={{ width: "10%" }}>{index + 1}</Td>
+                        {activeTab === "developer" && (
+                          <Td style={{ width: "30%" }}>{item.llmName}</Td>
+                        )}
+                        <Td
+                          style={{
+                            width: activeTab === "developer" ? "20%" : "30%",
+                          }}
                         >
-                          상세보기
-                        </ResultButton>
-                      </Td>
-                    </tr>
-                  )
-                )}
-              </tbody>
-            </Table>
+                          {item.totalScoreToString}
+                        </Td>
+                        <Td
+                          style={{
+                            width: activeTab === "developer" ? "30%" : "55%",
+                          }}
+                        >
+                          {new Date(item.createdAt).toLocaleString()}
+                        </Td>
+                        <Td
+                          style={{
+                            width: activeTab === "developer" ? "10%" : "5%",
+                          }}
+                        >
+                          <ResultButton
+                            href={`/${
+                              activeTab === "developer"
+                                ? "aiTestResult"
+                                : "userTestResult"
+                            }/${item.diagnosisId}`}
+                          >
+                            상세보기
+                          </ResultButton>
+                        </Td>
+                      </tr>
+                    )
+                  )}
+                </tbody>
+              </Table>
+            )}
           </TableContainer>
         </Container>
       </BlueContainer>
@@ -132,6 +140,7 @@ const BlueContainer = styled.div`
   width: 100%;
   padding: 2rem 0;
   background-color: ${color.primary};
+  min-height: 50vh;
 `;
 
 const Container = styled.div`

--- a/src/pages/UserTestInfo.jsx
+++ b/src/pages/UserTestInfo.jsx
@@ -14,7 +14,6 @@ import { color } from "../color";
 const UserTestInfo = () => {
   const [career, setCareer] = useState("");
   const [country, setCountry] = useState("");
-  const [llmName, setLlmName] = useState("이름 없음");
   const [careersList, setCareersList] = useState([]);
   const [countriesList, setCountriesList] = useState([]);
   const [error, setError] = useState("");
@@ -70,10 +69,7 @@ const UserTestInfo = () => {
       return;
     }
 
-    localStorage.setItem(
-      "diagnosisInfo",
-      JSON.stringify({ career, country, llmName })
-    );
+    localStorage.setItem("diagnosisInfo", JSON.stringify({ career, country }));
 
     window.location.href = "/userTestQuestion";
   };
@@ -107,15 +103,6 @@ const UserTestInfo = () => {
                 />
               </>
             )}
-            <FormGroup>
-              <Label>LLM 이름</Label>
-              <Input
-                type="text"
-                value={llmName}
-                onChange={(e) => setLlmName(e.target.value)}
-                placeholder="LLM 이름을 입력하세요"
-              />
-            </FormGroup>
             <br />
             {error && <ErrorMessage>{error}</ErrorMessage>}
             <OrangeButton type="submit" width={"100%"}>

--- a/src/pages/UserTestIntro.jsx
+++ b/src/pages/UserTestIntro.jsx
@@ -88,8 +88,14 @@ const UserTestIntro = () => {
             </TableRow>
           </Table>
         </ChecklistContainer>
-        <OrangeLinkButton href="/userTestinfo">
-          테스트 시작하기
+        <OrangeLinkButton
+          href={`${
+            localStorage.getItem("accessToken")
+              ? "/userTestQuestion"
+              : "/userTestinfo"
+          }`}
+        >
+          버튼 텍스트
         </OrangeLinkButton>
       </TestMainContent>
       <Footer />

--- a/src/pages/UserTestQuestion.jsx
+++ b/src/pages/UserTestQuestion.jsx
@@ -239,7 +239,7 @@ const AITestQuestion = () => {
     <HomepageLayout>
       <Menu />
       <Header>
-        <Title>인공지능 개발 윤리 검사</Title>
+        <Title>인공지능 사용자 윤리 검사</Title>
         <Content>
           아래 질문은 인공지능 윤리 기준의 10대 핵심요건에 대한 각각의 설명과
           그에 해당하는 점검항목입니다.
@@ -254,7 +254,7 @@ const AITestQuestion = () => {
             <Section key={standard.standardName}>
               <Standard>
                 <StyledStandard>
-                <StandardTitle>{standard.standardName}</StandardTitle>
+                  <StandardTitle>{standard.standardName}</StandardTitle>
                   <ProgressBar progress={calculateProgress()} />
                 </StyledStandard>
                 <FormattedDescription text={standard.description} />
@@ -334,8 +334,7 @@ const Standard = styled.div`
   }
 `;
 
-const StandardTitle = styled.h3`
-`;
+const StandardTitle = styled.h3``;
 
 const StyledStandard = styled.div`
   flex-direction: row;
@@ -410,8 +409,9 @@ const StyledButton = styled.button`
   border: none;
   border-radius: 50px;
   cursor: pointer;
-  font-family: 'NEXON Lv1 Gothic OTF';
-  src: url('https://fastly.jsdelivr.net/gh/projectnoonnu/noonfonts_20-04@2.1/NEXON Lv1 Gothic OTF.woff') format('woff');
+  font-family: "NEXON Lv1 Gothic OTF";
+  src: url("https://fastly.jsdelivr.net/gh/projectnoonnu/noonfonts_20-04@2.1/NEXON Lv1 Gothic OTF.woff")
+    format("woff");
   font-style: normal;
   &:hover {
     background-color: ${color.accent};

--- a/src/pages/UserTestResult.jsx
+++ b/src/pages/UserTestResult.jsx
@@ -304,10 +304,27 @@ const UserTestResult = () => {
               <StandardAndQuestion key={item.standardName}>
                 <StandardContainer>
                   <Standard>{item.standardName}</Standard>
+                  {item.description
+                    .split(".")
+                    .filter(Boolean)
+                    .map((sentence, index) => (
+                      <Description key={index}>{sentence.trim()}.</Description>
+                    ))}
                 </StandardContainer>
                 <QuestionContainer>
                   {item.qnaPairDtoList?.map((qna, index) => (
-                    <Question key={index}>{qna.question}</Question>
+                    <Question key={index}>
+                      {qna.question}
+                      <Answer>
+                        {" "}
+                        ▶{" "}
+                        {qna.answer === "NOT_APPLICABLE"
+                          ? "해당 없음"
+                          : qna.answer === "NO"
+                          ? "아니오"
+                          : qna.answer}
+                      </Answer>
+                    </Question>
                   ))}
                 </QuestionContainer>
               </StandardAndQuestion>
@@ -426,6 +443,13 @@ const Standard = styled.h3`
   color: white;
 `;
 
+const Description = styled.div`
+  margin-bottom: 1rem;
+  padding: 1rem;
+  background-color: white;
+  border-radius: 1rem;
+`;
+
 const QuestionContainer = styled.div`
   width: 100%;
   padding: 1rem 2rem;
@@ -436,4 +460,9 @@ const Question = styled.p`
   padding-bottom: 1rem;
   border-bottom: solid 0.05rem #ddd;
   line-height: 1.7;
+`;
+
+const Answer = styled.p`
+  margin-bottom: 0;
+  color: red;
 `;


### PR DESCRIPTION
## #️⃣연관된 이슈

> 관련 이슈 없음

## 📝작업 내용

> ![image](https://github.com/user-attachments/assets/af612236-56a0-4553-947a-b1edb2863fc5)
> 사용자 자가진단 정보 수집 부분의 LLM 이름 삭제 및 회원일때 페이지 넘김
>
>
> ![image](https://github.com/user-attachments/assets/cd50754b-a42d-4c42-9106-ba482c7b8b83)
> 자가진단 내역 없을 시 문구 추가 및 푸터 뜨는 현상 수정
>
>
> ![image](https://github.com/user-attachments/assets/199cd210-cdf5-43f6-8144-4bdeb89245a6)
> 결과 페이지 하단 오답 문항에 대해 10대 핵심요건의 정의와 각 문항의 답변 표시